### PR TITLE
[WALL] george / WALL-4961 / The negative sign for numeric values is also aligned right-to-left on the transaction page.

### DIFF
--- a/packages/api-v2/src/hooks/useCryptoTransactions.ts
+++ b/packages/api-v2/src/hooks/useCryptoTransactions.ts
@@ -1,7 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import useSubscription from '../useSubscription';
-import useActiveAccount from './useActiveAccount';
-import { displayMoney } from '../utils';
 
 type TTransaction = NonNullable<
     NonNullable<ReturnType<typeof useSubscription<'cashier_payments'>>['data']>['cashier_payments']
@@ -25,10 +23,6 @@ type TModifiedTransaction = Omit<TTransaction, 'status_code' | 'transaction_type
 const useCryptoTransactions = () => {
     const { subscribe, data, ...rest } = useSubscription('cashier_payments');
     const [transactions, setTransactions] = useState<TModifiedTransaction[]>();
-
-    const { data: account } = useActiveAccount();
-    const display_code = account?.currency_config?.display_code || 'USD';
-    const fractional_digits = account?.currency_config?.fractional_digits || 2;
 
     // Reset transactions data
     const resetData = useCallback(() => setTransactions(undefined), []);
@@ -68,14 +62,12 @@ const useCryptoTransactions = () => {
 
         return transactions.map(transaction => ({
             ...transaction,
-            /** Formatted amount */
-            formatted_amount: displayMoney(transaction.amount || 0, display_code, { fractional_digits }),
             /** Determine if the transaction is a deposit or not. */
             is_deposit: transaction.transaction_type === 'deposit',
             /** Determine if the transaction is a withdrawal or not. */
             is_withdrawal: transaction.transaction_type === 'withdrawal',
         }));
-    }, [display_code, fractional_digits, transactions]);
+    }, [transactions]);
 
     // Sort transactions by submit time.
     const sorted_transactions = useMemo(

--- a/packages/api-v2/src/hooks/useInfiniteTransactions.ts
+++ b/packages/api-v2/src/hooks/useInfiniteTransactions.ts
@@ -54,10 +54,6 @@ const useInfiniteTransactions = () => {
 
         return flatten_data?.map(transaction => ({
             ...transaction,
-            /** The transaction amount in currency format. */
-            display_amount: displayMoney(transaction?.amount || 0, display_code, {
-                fractional_digits,
-            }),
             /** The balance of account after the transaction in currency format. */
             display_balance_after: displayMoney(transaction?.balance_after || 0, display_code, { fractional_digits }),
         }));

--- a/packages/api-v2/src/utils/display-money.ts
+++ b/packages/api-v2/src/utils/display-money.ts
@@ -15,5 +15,5 @@ export const displayMoney = (
         locale: 'en-US',
     });
 
-    return `${formattedAmount} ${currency}`;
+    return formattedAmount + (currency ? ` ${currency}` : '');
 };

--- a/packages/wallets/src/components/AppCard/AppCard.tsx
+++ b/packages/wallets/src/components/AppCard/AppCard.tsx
@@ -9,7 +9,7 @@ import './AppCard.scss';
 type TProps = {
     activeWalletCurrency?: THooks.ActiveWalletAccount['currency'];
     appName?: JSX.Element | string;
-    balance?: string;
+    balance?: JSX.Element | string;
     cardSize: Extract<TGenericSizes, 'lg' | 'md' | 'sm'>;
     device: 'desktop' | 'mobile';
     isDemoWallet?: THooks.ActiveWalletAccount['is_virtual'];

--- a/packages/wallets/src/components/WalletCard/WalletCard.tsx
+++ b/packages/wallets/src/components/WalletCard/WalletCard.tsx
@@ -8,7 +8,7 @@ import { WalletGradientBackground } from '../WalletGradientBackground';
 import './WalletCard.scss';
 
 type TProps = {
-    balance: string;
+    balance: JSX.Element | string;
     currency: string;
     iconSize?: ComponentProps<typeof WalletCurrencyIcon>['size'];
     isCarouselContent?: boolean;

--- a/packages/wallets/src/components/WalletMoney/WalletMoney.tsx
+++ b/packages/wallets/src/components/WalletMoney/WalletMoney.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useCurrencyConfig } from '@deriv/api-v2';
+import { displayMoney } from '@deriv/api-v2/src/utils';
+
+type TProps = {
+    amount?: number;
+    currency?: string;
+    hasSign?: boolean;
+};
+
+const WalletMoney: React.FC<TProps> = ({ amount = 0, currency = '', hasSign = false }) => {
+    const { getConfig } = useCurrencyConfig();
+    const currencyConfig = getConfig(currency);
+
+    const fractionalDigits = currencyConfig?.fractional_digits;
+    const displayCode = currencyConfig?.display_code;
+
+    let sign = '';
+    if (Number(amount) && (Number(amount) < 0 || hasSign)) {
+        sign = Number(amount) > 0 ? '+' : '-';
+    }
+
+    const value = hasSign ? Math.abs(Number(amount)) : amount;
+
+    const formattedAmount = displayMoney(value, '', {
+        fractional_digits: fractionalDigits,
+    });
+
+    return (
+        <>
+            <span dir='ltr'>{(hasSign ? sign : '') + formattedAmount}</span>
+            {currency ? `\u00A0${displayCode}` : ''}
+        </>
+    );
+};
+
+export default WalletMoney;

--- a/packages/wallets/src/components/WalletMoney/__tests__/WalletMoney.spec.tsx
+++ b/packages/wallets/src/components/WalletMoney/__tests__/WalletMoney.spec.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import WalletMoney from '../WalletMoney';
+import '@testing-library/jest-dom';
+
+const mockCurrencyConfig = {
+    BTC: {
+        display_code: 'BTC',
+        fractional_digits: 8,
+    },
+    USD: {
+        display_code: 'USD',
+        fractional_digits: 2,
+    },
+};
+
+jest.mock('@deriv/api-v2', () => ({
+    useCurrencyConfig: jest.fn(() => ({
+        getConfig: (currency: 'BTC' | 'USD') => mockCurrencyConfig[currency],
+    })),
+}));
+
+describe('WalletMoney', () => {
+    it('renders with default props', () => {
+        const { container } = render(<WalletMoney />);
+
+        expect(container).toHaveTextContent('0.00');
+    });
+
+    it('renders positive amount with a sign', () => {
+        const { container } = render(<WalletMoney amount={1000} currency='USD' hasSign />);
+
+        expect(container).toHaveTextContent('+1,000.00 USD');
+    });
+
+    it('renders negative amount with sign', () => {
+        const { container } = render(<WalletMoney amount={-500} currency='USD' hasSign={true} />);
+
+        expect(container).toHaveTextContent('-500.00 USD');
+    });
+
+    it('applies fractional digits from currency config', () => {
+        const { container } = render(<WalletMoney amount={5} currency='BTC' />);
+
+        expect(container).toHaveTextContent('5.00000000 BTC');
+    });
+
+    it('renders without currency code if no currency is provided', () => {
+        const { container } = render(<WalletMoney amount={500} hasSign={false} />);
+
+        expect(container).toHaveTextContent('500.00');
+    });
+});

--- a/packages/wallets/src/components/WalletMoney/index.ts
+++ b/packages/wallets/src/components/WalletMoney/index.ts
@@ -1,0 +1,1 @@
+export { default as WalletMoney } from './WalletMoney';

--- a/packages/wallets/src/components/index.ts
+++ b/packages/wallets/src/components/index.ts
@@ -30,6 +30,7 @@ export * from './WalletListCardDropdown';
 export * from './WalletListHeader';
 export * from './WalletMarketCurrencyIcon';
 export * from './WalletMarketIcon';
+export * from './WalletMoney';
 export * from './WalletsAddMoreCarousel';
 export * from './WalletsCarousel';
 export * from './WalletsCarouselContent';

--- a/packages/wallets/src/features/cashier/modules/TransactionStatus/components/CryptoTransaction/CryptoTransaction.tsx
+++ b/packages/wallets/src/features/cashier/modules/TransactionStatus/components/CryptoTransaction/CryptoTransaction.tsx
@@ -5,6 +5,7 @@ import { LegacyClose1pxIcon } from '@deriv/quill-icons';
 import { getTruncatedString } from '@deriv/utils';
 import { Localize, useTranslations } from '@deriv-com/translations';
 import { Button, Text, useDevice } from '@deriv-com/ui';
+import { WalletMoney } from '../../../../../../components';
 import { useModal } from '../../../../../../components/ModalProvider';
 import { THooks } from '../../../../../../types';
 import { getFormattedDateString } from '../../../../../../utils/utils';
@@ -13,6 +14,7 @@ import { getFormattedConfirmations, getStatusName } from '../../../../helpers/tr
 import './CryptoTransaction.scss';
 
 type TCryptoTransaction = {
+    currency: THooks.ActiveAccount['currency'];
     currencyDisplayCode: THooks.CurrencyConfig['code'];
     currencyDisplayFraction?: THooks.CurrencyConfig['fractional_digits'];
     // TODO: Remove transaction_fee from transaction type once API is updated
@@ -21,7 +23,8 @@ type TCryptoTransaction = {
 };
 
 const CryptoTransaction: React.FC<TCryptoTransaction> = ({
-    currencyDisplayCode: currency,
+    currency,
+    currencyDisplayCode,
     currencyDisplayFraction,
     transaction,
 }) => {
@@ -72,9 +75,12 @@ const CryptoTransaction: React.FC<TCryptoTransaction> = ({
             <div className='wallets-crypto-transaction__type-and-status'>
                 <Text align='start' lineHeight='sm' size='xs'>
                     {transaction.is_deposit ? (
-                        <Localize i18n_default_text='Deposit {{currency}}' values={{ currency }} />
+                        <Localize i18n_default_text='Deposit {{currency}}' values={{ currency: currencyDisplayCode }} />
                     ) : (
-                        <Localize i18n_default_text='Withdrawal {{currency}}' values={{ currency }} />
+                        <Localize
+                            i18n_default_text='Withdrawal {{currency}}'
+                            values={{ currency: currencyDisplayCode }}
+                        />
                     )}
                 </Text>
                 <div className='wallets-crypto-transaction__status'>
@@ -102,7 +108,7 @@ const CryptoTransaction: React.FC<TCryptoTransaction> = ({
             </div>
             <div className='wallets-crypto-transaction__amount-and-date'>
                 <Text align='start' color='less-prominent' size='2xs'>
-                    {transaction.formatted_amount}
+                    <WalletMoney amount={transaction.amount} currency={currency} />
                 </Text>
                 <Text align='start' color='less-prominent' size='2xs'>
                     {getFormattedDateString(
@@ -118,7 +124,7 @@ const CryptoTransaction: React.FC<TCryptoTransaction> = ({
                     <Localize
                         i18n_default_text='Transaction fee: {{fee}} {{currency}}'
                         values={{
-                            currency,
+                            currency: currencyDisplayCode,
                             fee: Number(transaction.transaction_fee).toFixed(currencyDisplayFraction),
                         }}
                     />

--- a/packages/wallets/src/features/cashier/modules/TransactionStatus/components/CryptoTransaction/__tests__/CryptoTransaction.spec.tsx
+++ b/packages/wallets/src/features/cashier/modules/TransactionStatus/components/CryptoTransaction/__tests__/CryptoTransaction.spec.tsx
@@ -5,8 +5,22 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import { ModalProvider } from '../../../../../../../components/ModalProvider';
 import CryptoTransaction from '../CryptoTransaction';
 
+const mockCurrencyConfig = {
+    BTC: {
+        display_code: 'BTC',
+        fractional_digits: 8,
+    },
+    USD: {
+        display_code: 'USD',
+        fractional_digits: 2,
+    },
+};
+
 jest.mock('@deriv/api-v2', () => ({
     useCancelCryptoTransaction: jest.fn(),
+    useCurrencyConfig: jest.fn(() => ({
+        getConfig: (currency: 'BTC' | 'USD') => mockCurrencyConfig[currency],
+    })),
 }));
 
 const mockModalHide = jest.fn();
@@ -52,7 +66,7 @@ describe('CryptoTransaction', () => {
 
         render(
             <ModalProvider>
-                <CryptoTransaction currencyDisplayCode='BTC' transaction={mockTransaction} />
+                <CryptoTransaction currency='BTC' currencyDisplayCode='BTC' transaction={mockTransaction} />
             </ModalProvider>
         );
 
@@ -83,7 +97,7 @@ describe('CryptoTransaction', () => {
 
         render(
             <ModalProvider>
-                <CryptoTransaction currencyDisplayCode='BTC' transaction={mockDepositTransaction} />
+                <CryptoTransaction currency='BTC' currencyDisplayCode='BTC' transaction={mockDepositTransaction} />
             </ModalProvider>
         );
 
@@ -103,7 +117,7 @@ describe('CryptoTransaction', () => {
 
         render(
             <ModalProvider>
-                <CryptoTransaction currencyDisplayCode='BTC' transaction={mockTransaction} />
+                <CryptoTransaction currency='BTC' currencyDisplayCode='BTC' transaction={mockTransaction} />
             </ModalProvider>
         );
 
@@ -123,7 +137,7 @@ describe('CryptoTransaction', () => {
 
         render(
             <ModalProvider>
-                <CryptoTransaction currencyDisplayCode='BTC' transaction={mockTransaction} />
+                <CryptoTransaction currency='BTC' currencyDisplayCode='BTC' transaction={mockTransaction} />
             </ModalProvider>
         );
 
@@ -146,7 +160,7 @@ describe('CryptoTransaction', () => {
 
         render(
             <ModalProvider>
-                <CryptoTransaction currencyDisplayCode='BTC' transaction={mockTransaction} />
+                <CryptoTransaction currency='BTC' currencyDisplayCode='BTC' transaction={mockTransaction} />
             </ModalProvider>
         );
 

--- a/packages/wallets/src/features/cashier/modules/TransactionStatus/components/TransactionStatusSuccess/TransactionStatusSuccess.tsx
+++ b/packages/wallets/src/features/cashier/modules/TransactionStatus/components/TransactionStatusSuccess/TransactionStatusSuccess.tsx
@@ -26,6 +26,7 @@ const TransactionStatusSuccess: React.FC<TTransactionStatusSuccess> = ({ transac
                     {filteredTransactions?.slice(0, 3).map((transaction, index) => (
                         <React.Fragment key={transaction.id}>
                             <CryptoTransaction
+                                currency={wallet.currency || ''}
                                 currencyDisplayCode={wallet.currency_config?.code || ''}
                                 currencyDisplayFraction={wallet.currency_config?.fractional_digits || 0}
                                 key={transaction.id}

--- a/packages/wallets/src/features/cashier/modules/TransactionStatus/components/TransactionStatusSuccess/__tests__/TransactionStatusSuccess.spec.tsx
+++ b/packages/wallets/src/features/cashier/modules/TransactionStatus/components/TransactionStatusSuccess/__tests__/TransactionStatusSuccess.spec.tsx
@@ -6,6 +6,23 @@ import WalletsAuthProvider from '../../../../../../../AuthProvider';
 import { ModalProvider } from '../../../../../../../components/ModalProvider';
 import TransactionStatusSuccess from '../TransactionStatusSuccess';
 
+const mockCurrencyConfig = {
+    BTC: {
+        display_code: 'BTC',
+        fractional_digits: 8,
+    },
+    USD: {
+        display_code: 'USD',
+        fractional_digits: 2,
+    },
+};
+
+jest.mock('@deriv/api-v2', () => ({
+    ...jest.requireActual('@deriv/api-v2'),
+    useCurrencyConfig: jest.fn(() => ({
+        getConfig: (currency: 'BTC' | 'USD') => mockCurrencyConfig[currency],
+    })),
+}));
 jest.mock('react-router-dom', () => ({
     useHistory: jest.fn(),
 }));
@@ -37,7 +54,7 @@ const mockWallet = {
     balance: 1,
     broker: '',
     created_at: new Date('01/01/1970'),
-    currency: '',
+    currency: 'BTC',
     currency_config: {
         code: '',
         display_code: '',
@@ -104,7 +121,7 @@ describe('TransactionStatusSuccess', () => {
     });
 
     it('should render withdrawal info for withdrawal transactions', () => {
-        render(
+        const { container } = render(
             <APIProvider>
                 <WalletsAuthProvider>
                     <ModalProvider>
@@ -119,7 +136,7 @@ describe('TransactionStatusSuccess', () => {
         );
 
         expect(screen.getByText(/Withdrawal/)).toBeInTheDocument();
-        expect(screen.getByText('0.00010000 BTC')).toBeInTheDocument();
+        expect(container).toHaveTextContent('0.00010000 BTC');
         expect(screen.queryByText('No recent transactions.')).not.toBeInTheDocument();
         expect(screen.queryByText('View more')).not.toBeInTheDocument();
     });
@@ -145,7 +162,7 @@ describe('TransactionStatusSuccess', () => {
             },
         ];
 
-        render(
+        const { container } = render(
             <APIProvider>
                 <WalletsAuthProvider>
                     <ModalProvider>
@@ -160,7 +177,7 @@ describe('TransactionStatusSuccess', () => {
         );
 
         expect(screen.getByText(/Deposit/)).toBeInTheDocument();
-        expect(screen.getByText('0.00010000 BTC')).toBeInTheDocument();
+        expect(container).toHaveTextContent('0.00010000 BTC');
         expect(screen.queryByText('No recent transactions.')).not.toBeInTheDocument();
         expect(screen.queryByText('View more')).not.toBeInTheDocument();
     });
@@ -208,7 +225,7 @@ describe('TransactionStatusSuccess', () => {
             mockTransactions.push(newTransaction);
         }
 
-        render(
+        const { container } = render(
             <APIProvider>
                 <WalletsAuthProvider>
                     <ModalProvider>
@@ -224,7 +241,7 @@ describe('TransactionStatusSuccess', () => {
 
         expect(screen.queryByText('No recent transactions.')).not.toBeInTheDocument();
         expect(screen.getAllByText(/Withdrawal/)[0]).toBeInTheDocument();
-        expect(screen.getAllByText('0.00010000 BTC')[0]).toBeInTheDocument();
+        expect(container).toHaveTextContent('0.00010000 BTC');
         expect(screen.getByText('View more')).toBeInTheDocument();
 
         fireEvent.click(screen.getByText('View more'));

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/TransactionsCompletedRow.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/TransactionsCompletedRow.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { useDebounceCallback } from 'usehooks-ts';
 import { Localize, useTranslations } from '@deriv-com/translations';
 import { Divider, Text } from '@deriv-com/ui';
-import { WalletClipboard } from '../../../../../../components';
+import { WalletClipboard, WalletMoney } from '../../../../../../components';
 import { THooks } from '../../../../../../types';
 import parseCryptoLongcode from '../../../../../../utils/parse-crypto-longcode';
 import { getTransactionLabels } from '../../constants';
@@ -97,8 +97,7 @@ const TransactionsCompletedRowContent: React.FC<TTransactionsCompletedRowContent
                     size='xs'
                     weight='bold'
                 >
-                    {transaction.amount && transaction.amount > 0 ? '+' : ''}
-                    {transaction.display_amount}
+                    <WalletMoney amount={transaction.amount} currency={currency} hasSign />
                 </Text>
                 <Text color='primary' size='2xs'>
                     <Localize

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/__tests__/TransactionsCompletedRow.spec.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/__tests__/TransactionsCompletedRow.spec.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
+import { APIProvider } from '@deriv/api-v2';
 import { render, screen } from '@testing-library/react';
+import WalletsAuthProvider from '../../../../../../../AuthProvider';
 import { THooks } from '../../../../../../../types';
 import TransactionsCompletedRow from '../TransactionsCompletedRow';
 
@@ -44,9 +46,19 @@ const mockTransaction: THooks.Transactions = {
     },
 };
 
+const wrapper = ({ children }: PropsWithChildren<unknown>) => {
+    return (
+        <APIProvider>
+            <WalletsAuthProvider>{children}</WalletsAuthProvider>
+        </APIProvider>
+    );
+};
+
 describe('TransactionsCompletedRow', () => {
     it('renders deposit transaction details correctly', () => {
-        render(<TransactionsCompletedRow accounts={mockAccounts} transaction={mockTransaction} wallet={mockWallet} />);
+        render(<TransactionsCompletedRow accounts={mockAccounts} transaction={mockTransaction} wallet={mockWallet} />, {
+            wrapper,
+        });
 
         expect(screen.getByText('+100.00')).toBeInTheDocument();
         expect(screen.getByText('Balance: 200.00')).toBeInTheDocument();
@@ -60,7 +72,8 @@ describe('TransactionsCompletedRow', () => {
         };
 
         render(
-            <TransactionsCompletedRow accounts={mockAccounts} transaction={transferTransaction} wallet={mockWallet} />
+            <TransactionsCompletedRow accounts={mockAccounts} transaction={transferTransaction} wallet={mockWallet} />,
+            { wrapper }
         );
 
         expect(screen.getByText('Balance: 200.00')).toBeInTheDocument();
@@ -86,7 +99,8 @@ describe('TransactionsCompletedRow', () => {
                 accounts={mockAccounts}
                 transaction={withdrawalTransaction}
                 wallet={mockWithdrawalWallet}
-            />
+            />,
+            { wrapper }
         );
 
         expect(screen.getByText('-50.00')).toBeInTheDocument();
@@ -102,7 +116,12 @@ describe('TransactionsCompletedRow', () => {
         };
 
         const { container } = render(
-            <TransactionsCompletedRow accounts={mockAccounts} transaction={incompleteTransaction} wallet={mockWallet} />
+            <TransactionsCompletedRow
+                accounts={mockAccounts}
+                transaction={incompleteTransaction}
+                wallet={mockWallet}
+            />,
+            { wrapper }
         );
 
         expect(container).toBeEmptyDOMElement();

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsPendingRow/TransactionsPendingRow.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsPendingRow/TransactionsPendingRow.tsx
@@ -5,8 +5,8 @@ import { LegacyClose1pxIcon } from '@deriv/quill-icons';
 import { getTruncatedString } from '@deriv/utils';
 import { Localize, useTranslations } from '@deriv-com/translations';
 import { Button, Divider, Text, Tooltip, useDevice } from '@deriv-com/ui';
+import { WalletCurrencyCard, WalletMoney } from '../../../../../../components';
 import { useModal } from '../../../../../../components/ModalProvider';
-import { WalletCurrencyCard } from '../../../../../../components/WalletCurrencyCard';
 import useIsRtl from '../../../../../../hooks/useIsRtl';
 import { THooks } from '../../../../../../types';
 import { getFormattedDateString, getFormattedTimeString } from '../../../../../../utils/utils';
@@ -25,10 +25,10 @@ type TProps = {
 };
 
 const TransactionsPendingRow: React.FC<TProps> = ({ transaction }) => {
-    const { data } = useActiveWalletAccount();
+    const { data: activeWallet } = useActiveWalletAccount();
     const { isDesktop } = useDevice();
     const { localize } = useTranslations();
-    const displayCode = useMemo(() => data?.currency_config?.display_code || 'USD', [data]);
+    const displayCode = useMemo(() => activeWallet?.currency_config?.display_code || 'USD', [activeWallet]);
     const modal = useModal();
     const isRtl = useIsRtl();
     const formattedTransactionHash = transaction.transaction_hash
@@ -94,7 +94,11 @@ const TransactionsPendingRow: React.FC<TProps> = ({ transaction }) => {
             <Divider color='var(--border-divider)' />
             <div className='wallets-transactions-pending-row'>
                 <div className='wallets-transactions-pending-row__wallet-info'>
-                    <WalletCurrencyCard currency={data?.currency || 'USD'} isDemo={data?.is_virtual} size='md' />
+                    <WalletCurrencyCard
+                        currency={activeWallet?.currency || 'USD'}
+                        isDemo={activeWallet?.is_virtual}
+                        size='md'
+                    />
                     <div className='wallets-transactions-pending-row__column'>
                         <Text align='start' color='primary' size='xs'>
                             {getTransactionLabels(localize)[transaction.transaction_type]}
@@ -138,7 +142,15 @@ const TransactionsPendingRow: React.FC<TProps> = ({ transaction }) => {
                         <React.Fragment>
                             <TransactionsPendingRowField
                                 name={localize('Amount')}
-                                value={`${transaction.is_deposit ? '+' : '-'}${transaction.formatted_amount}`}
+                                value={
+                                    <WalletMoney
+                                        amount={
+                                            transaction.is_deposit ? transaction.amount : -(transaction.amount || 0)
+                                        }
+                                        currency={activeWallet?.currency}
+                                        hasSign
+                                    />
+                                }
                                 valueTextProps={{
                                     color: transaction.is_deposit ? 'success' : 'red',
                                 }}
@@ -177,8 +189,11 @@ const TransactionsPendingRow: React.FC<TProps> = ({ transaction }) => {
                                 size='sm'
                                 weight='bold'
                             >
-                                {transaction.is_deposit ? '+' : '-'}
-                                {transaction.formatted_amount}
+                                <WalletMoney
+                                    amount={transaction.is_deposit ? transaction.amount : -(transaction.amount || 0)}
+                                    currency={activeWallet?.currency}
+                                    hasSign
+                                />
                             </Text>
                         </div>
                     )}

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsPendingRow/__tests__/TransactionsPendingRow.spec.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsPendingRow/__tests__/TransactionsPendingRow.spec.tsx
@@ -5,6 +5,17 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { ModalProvider } from '../../../../../../../components/ModalProvider';
 import TransactionsPendingRow from '../TransactionsPendingRow';
 
+const mockCurrencyConfig = {
+    BTC: {
+        display_code: 'BTC',
+        fractional_digits: 8,
+    },
+    USD: {
+        display_code: 'USD',
+        fractional_digits: 2,
+    },
+};
+
 jest.mock('@deriv/api-v2', () => ({
     useActiveWalletAccount: jest.fn(() => ({
         data: {
@@ -12,6 +23,9 @@ jest.mock('@deriv/api-v2', () => ({
         },
     })),
     useCancelCryptoTransaction: jest.fn(() => ({ mutate: jest.fn() })),
+    useCurrencyConfig: jest.fn(() => ({
+        getConfig: (currency: 'BTC' | 'USD') => mockCurrencyConfig[currency],
+    })),
 }));
 
 jest.mock('react-router-dom', () => ({
@@ -29,7 +43,7 @@ jest.mock('@deriv-com/ui', () => ({
 const mockWithdrawal = {
     address_hash: '',
     address_url: '',
-    amount: 0.0002,
+    amount: 0.02,
     description: '',
     formatted_amount: '',
     id: '0123',
@@ -84,7 +98,7 @@ describe('TransactionsPendingRow', () => {
         expect(screen.getByText('Transaction hash')).toBeInTheDocument();
         expect(screen.getByText('USD Wallet')).toBeInTheDocument();
         expect(screen.getAllByText('Pending')[0]).toBeInTheDocument();
-        expect(screen.getByText('-')).toBeInTheDocument();
+        expect(screen.getByText('-0.02')).toBeInTheDocument();
     });
 
     it('should render component with correct contents for deposit on desktop', () => {
@@ -98,7 +112,7 @@ describe('TransactionsPendingRow', () => {
         expect(screen.getByText('Transaction hash')).toBeInTheDocument();
         expect(screen.getByText('USD Wallet')).toBeInTheDocument();
         expect(screen.getAllByText('Pending')[0]).toBeInTheDocument();
-        expect(screen.getByText('+')).toBeInTheDocument();
+        expect(screen.getByText('+0.02')).toBeInTheDocument();
     });
 
     it('should render component with correct contents for withdrawal for mobile/responsive', () => {
@@ -113,7 +127,7 @@ describe('TransactionsPendingRow', () => {
         expect(screen.getByText('USD Wallet')).toBeInTheDocument();
         expect(screen.getAllByText('Pending')[0]).toBeInTheDocument();
         expect(screen.getByText('Cancel transaction')).toBeInTheDocument();
-        expect(screen.getByText('-')).toBeInTheDocument();
+        expect(screen.getByText('-0.02')).toBeInTheDocument();
     });
 
     it('should render component with correct contents for deposit on mobile/responsive', () => {
@@ -128,7 +142,7 @@ describe('TransactionsPendingRow', () => {
         expect(screen.getByText('USD Wallet')).toBeInTheDocument();
         expect(screen.getAllByText('Pending')[0]).toBeInTheDocument();
         expect(screen.getByText('Cancel transaction')).toBeInTheDocument();
-        expect(screen.getByText('+')).toBeInTheDocument();
+        expect(screen.getByText('+0.02')).toBeInTheDocument();
     });
 
     it('should show modal on click of cancel button in mobile', () => {

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferReceipt/TransferReceipt.scss
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferReceipt/TransferReceipt.scss
@@ -51,4 +51,8 @@
         justify-content: center;
         align-items: center;
     }
+
+    &__amount-conversion {
+        display: inline-flex;
+    }
 }

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferReceipt/TransferReceipt.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferReceipt/TransferReceipt.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { LegacyArrowLeft2pxIcon, LegacyArrowRight2pxIcon } from '@deriv/quill-icons';
 import { Localize } from '@deriv-com/translations';
 import { Button, Text, useDevice } from '@deriv-com/ui';
-import { AppCard, WalletCard } from '../../../../../../components';
+import { AppCard, WalletCard, WalletMoney } from '../../../../../../components';
 import useIsRtl from '../../../../../../hooks/useIsRtl';
 import { TPlatforms } from '../../../../../../types';
 import { useTransfer } from '../../provider';
@@ -12,7 +12,7 @@ import './TransferReceipt.scss';
 type TReceiptCardProps = {
     account: NonNullable<ReturnType<typeof useTransfer>['receipt']>['fromAccount'];
     activeWallet: ReturnType<typeof useTransfer>['activeWallet'];
-    balance: string;
+    balance: JSX.Element | string;
 };
 
 const ReceiptCard: React.FC<TReceiptCardProps> = ({ account, activeWallet, balance }) => {
@@ -59,15 +59,7 @@ const TransferReceipt = () => {
     const { feeAmount, fromAccount, fromAmount, toAccount, toAmount } = receipt;
 
     const isSameCurrency = fromAccount?.currency === toAccount?.currency;
-    const displayTransferredFromAmount = `${fromAmount.toFixed(fromAccount?.currencyConfig?.fractional_digits)} ${
-        fromAccount?.currencyConfig?.display_code
-    }`;
-    const displayTransferredToAmount = `${toAmount.toFixed(toAccount?.currencyConfig?.fractional_digits)} ${
-        toAccount?.currencyConfig?.display_code
-    }`;
-    const transferredAmountMessage = isSameCurrency
-        ? displayTransferredFromAmount
-        : `${displayTransferredFromAmount} (${displayTransferredToAmount})`;
+
     const feeMessage = feeAmount ? (
         <Localize
             i18n_default_text='Transfer fees: {{feeAmount}} {{displayCode}}'
@@ -86,7 +78,7 @@ const TransferReceipt = () => {
                 <ReceiptCard
                     account={fromAccount}
                     activeWallet={activeWallet}
-                    balance={`-${displayTransferredFromAmount}`}
+                    balance={<WalletMoney amount={-fromAmount} currency={fromAccount?.currency} hasSign />}
                 />
                 <div className='wallets-transfer-receipt__arrow-icon'>
                     {isRtl ? <LegacyArrowLeft2pxIcon iconSize='xs' /> : <LegacyArrowRight2pxIcon iconSize='xs' />}
@@ -94,7 +86,7 @@ const TransferReceipt = () => {
                 <ReceiptCard
                     account={toAccount}
                     activeWallet={activeWallet}
-                    balance={`+${displayTransferredToAmount}`}
+                    balance={<WalletMoney amount={toAmount} currency={toAccount?.currency} hasSign />}
                 />
             </div>
             <div
@@ -103,9 +95,24 @@ const TransferReceipt = () => {
                 })}
             >
                 <div className='wallets-transfer-receipt__amount'>
-                    <Text size='xl' weight='bold'>
-                        {transferredAmountMessage}
-                    </Text>
+                    {isSameCurrency && (
+                        <Text size='xl' weight='bold'>
+                            <WalletMoney amount={fromAmount} currency={fromAccount?.currency} />
+                        </Text>
+                    )}
+                    {!isSameCurrency && (
+                        <div className='wallets-transfer-receipt__amount-conversion'>
+                            <Text as='div' size='xl' weight='bold'>
+                                <WalletMoney amount={fromAmount} currency={fromAccount?.currency} />
+                                {'\u00A0'}
+                            </Text>
+                            <Text as='div' size='xl' weight='bold'>
+                                {'('}
+                                <WalletMoney amount={toAmount} currency={toAccount?.currency} />
+                                {')'}
+                            </Text>
+                        </div>
+                    )}
                     {Boolean(feeMessage) && (
                         <Text color='less-prominent' size='md'>
                             {feeMessage}

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferReceipt/__tests__/TransferReceipt.spec.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferReceipt/__tests__/TransferReceipt.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import React, { PropsWithChildren } from 'react';
 import { APIProvider } from '@deriv/api-v2';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import WalletsAuthProvider from '../../../../../../../AuthProvider';
 import { TransferProvider } from '../../../provider';
@@ -47,8 +47,22 @@ const ACCOUNTS = [
     },
 ] as NonNullable<TAccount>[];
 
+const mockCurrencyConfig = {
+    BTC: {
+        display_code: 'BTC',
+        fractional_digits: 8,
+    },
+    USD: {
+        display_code: 'USD',
+        fractional_digits: 2,
+    },
+};
+
 jest.mock('@deriv/api-v2', () => ({
     ...jest.requireActual('@deriv/api-v2'),
+    useCurrencyConfig: jest.fn(() => ({
+        getConfig: (currency: 'BTC' | 'USD') => mockCurrencyConfig[currency],
+    })),
     useTransferBetweenAccounts: jest.fn(() => ({
         data: { accounts: ACCOUNTS },
     })),
@@ -118,10 +132,10 @@ const wrapper = ({ children }: PropsWithChildren<unknown>) => {
 
 describe('TransferReceipt', () => {
     it('Should render the correct fee message and label', () => {
-        render(<TransferReceipt />, { wrapper });
+        const { container } = render(<TransferReceipt />, { wrapper });
 
-        expect(screen.queryByText('10000.00 USD (100.00000000 BTC)')).toBeInTheDocument();
-        expect(screen.queryByText('Transfer fees: 100 USD')).toBeInTheDocument();
+        expect(container).toHaveTextContent('10,000.00 USD (100.00000000 BTC)');
+        expect(container).toHaveTextContent('Transfer fees: 100 USD');
     });
     it('Should render the correct from and to card labels', () => {
         render(<TransferReceipt />, { wrapper });
@@ -129,8 +143,8 @@ describe('TransferReceipt', () => {
         const fromCard = screen.getByTestId('dt_wallets_app_card');
         const toCard = screen.getByTestId('dt_wallets_wallet_card');
 
-        expect(within(fromCard).getByText('-10000.00 USD')).toBeInTheDocument();
-        expect(within(toCard).queryByText('+100.00000000 BTC')).toBeInTheDocument();
+        expect(fromCard).toHaveTextContent('-10,000.00 USD');
+        expect(toCard).toHaveTextContent('+100.00000000 BTC');
     });
     it('Should invoke reset transfer when the reset button is clicked', () => {
         render(<TransferReceipt />, { wrapper });

--- a/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/components/WithdrawalCryptoReceipt/WithdrawalCryptoReceipt.tsx
+++ b/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/components/WithdrawalCryptoReceipt/WithdrawalCryptoReceipt.tsx
@@ -3,7 +3,7 @@ import { useHistory } from 'react-router-dom';
 import { LegacyArrowDown2pxIcon } from '@deriv/quill-icons';
 import { Localize } from '@deriv-com/translations';
 import { Button, Text } from '@deriv-com/ui';
-import { WalletCard } from '../../../../../../components';
+import { WalletCard, WalletMoney } from '../../../../../../components';
 import { TWithdrawalReceipt } from '../../types';
 import { WithdrawalCryptoDestinationAddress } from './components';
 import './WithdrawalCryptoReceipt.scss';
@@ -15,12 +15,16 @@ type TProps = {
 
 const WithdrawalCryptoReceipt: React.FC<TProps> = ({ onClose, withdrawalReceipt }) => {
     const history = useHistory();
-    const { address, amount, amountReceived, currency, transactionFee } = withdrawalReceipt;
+    const { address, amount = 0, amountReceived, currency, transactionFee } = withdrawalReceipt;
 
     return (
         <div className='wallets-withdrawal-crypto-receipt'>
             <div className='wallets-withdrawal-crypto-receipt__accounts-info'>
-                <WalletCard balance={`-${amount} ${currency}`} currency={currency ?? ''} iconSize='md' />
+                <WalletCard
+                    balance={<WalletMoney amount={-amount} currency={currency} hasSign />}
+                    currency={currency ?? ''}
+                    iconSize='md'
+                />
                 <LegacyArrowDown2pxIcon iconSize='xs' />
                 <WithdrawalCryptoDestinationAddress address={address} />
             </div>

--- a/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/provider/WithdrawalCryptoProvider.tsx
+++ b/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/provider/WithdrawalCryptoProvider.tsx
@@ -161,7 +161,7 @@ const WithdrawalCryptoProvider: React.FC<React.PropsWithChildren<TWithdrawalCryp
                 const fractionalDigits = activeWallet?.currency_config?.fractional_digits ?? 0;
                 setWithdrawalReceipt({
                     address,
-                    amount: amount?.toFixed(fractionalDigits),
+                    amount: Number(amount),
                     amountReceived: estimatedFeeUniqueId
                         ? (Number(amount) - Number(cryptoEstimationsFee)).toFixed(fractionalDigits)
                         : amount?.toFixed(fractionalDigits),

--- a/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/types/types.ts
+++ b/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/types/types.ts
@@ -6,7 +6,7 @@ export type TWithdrawalForm = {
 
 export type TWithdrawalReceipt = {
     address?: string;
-    amount?: string;
+    amount?: number;
     amountReceived?: string;
     currency?: string;
     landingCompany?: string;


### PR DESCRIPTION
## Changes:

- add alignment support for positive/negative sign for amount for RTL language

### Screenshots:

![Screenshot 2024-09-27 at 20 23 56](https://github.com/user-attachments/assets/acd8f42d-760e-4110-b63b-82cfb5a6f9bb)
![Screenshot 2024-09-27 at 20 24 07](https://github.com/user-attachments/assets/fa544a34-68ba-4505-8443-da0e8ab2799c)
![Screenshot 2024-09-27 at 20 25 46](https://github.com/user-attachments/assets/fea83e3d-63f8-4aa5-a9ff-291965e4897e)
![Screenshot 2024-09-30 at 10 44 04](https://github.com/user-attachments/assets/9cf7012b-f88e-410b-8968-ad6ebdf835f2)

